### PR TITLE
changing the pagesize using file, document properties would introduce…

### DIFF
--- a/unittests/alltests.py
+++ b/unittests/alltests.py
@@ -24,6 +24,8 @@ def make_suite(test):
 
 tests = (countersheetstest.CountersheetsTest,
          countersheetstest.SingleCounterTest,
+         countersheetstest.LayerTranslationTest,
+         countersheetstest.DocumentTopLeftCoordinateConverterTest,
          countertest.SingleCounterTest,
          csvcounterdefinitionparsertest.CSVCounterDefinitionParserTest,
          csvcounterfactorytest.CSVCounterFactoryTest,


### PR DESCRIPTION
… a transform between the counter layer and the output layers, which would result in mis-positioning of counters on output layers.

This fixes the bug I raised, "page size other than A4 results in counter positioning errors #12"