### PR TITLE
Fix embedded images

### DIFF
--- a/countersheet.py
+++ b/countersheet.py
@@ -1690,7 +1690,10 @@ class CountersheetEffect(inkex.Effect):
         return backlayer
 
     def make_image_href(self, filename):
-        if os.path.isabs(filename):
+
+        if filename.startswith("data:"):
+            return filename
+        elif os.path.isabs(filename):
             return filename
         else:
             return os.path.join(self.imagedir, filename)


### PR DESCRIPTION
Hi Pelle!
I am sending trivial PR which fixes problem with embedded images. Current problem is, that filename will not always be a filename, but in case of embedded images - there are binary data representing image. If we add path to it - it will all break.

I am just recognizing fact filename begins with "data:" and if it is the case - returns it as is.

Solves #74.

Have a great day!