### PR TITLE
recognize file:// absolute path

### DIFF
--- a/countersheet.py
+++ b/countersheet.py
@@ -1693,7 +1693,7 @@ class CountersheetEffect(inkex.Effect):
 
         if filename.startswith("data:"):
             return filename
-        elif os.path.isabs(filename):
+        elif os.path.isabs(filename) or filename.startswith("file://"):
             return filename
         else:
             return os.path.join(self.imagedir, filename)


### PR DESCRIPTION
Hi Pelle!
Another trivial PR to fix linked images. In essence problem is, that:
`file://ABSOLUTE_PATH` is not recognized by os.path.isabs as absolute, which is logical, but not what we want. I had added condition to check it.
I am not checking if path without file:// is absolute, but it should.

https://en.wikipedia.org/wiki/File_URI_scheme

There is variant with hostname, but even if we encounter (which is unlikely) it - it would not work IMHO.

Related to #74.
