### PR TITLE
Allow 180 degree component rotation

### DIFF
--- a/countersheet.py
+++ b/countersheet.py
@@ -466,7 +466,7 @@ class CountersheetEffect(inkex.Effect):
             element.set('transform', translate)
 
     def rotate_element(self, element, degrees, width, height):
-        if degrees == 0 or degrees == 180:
+        if degrees == 0:
             return
         rotate = "rotate(%f,%f,%f)" % (degrees,
                                           width / 2.0,


### PR DESCRIPTION
I found useful to be able to rotate component 180 degrees. It is blocked by default in code, but available in GUI as option. I think there is no reason for that. I had used it few times and it always worked as expected.